### PR TITLE
add usage of audio tag and file_id of drive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8813,7 +8813,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8832,7 +8831,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9012,8 +9010,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9119,8 +9116,7 @@
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13468,7 +13464,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -19,6 +19,13 @@
           target="_blank"
           class="button--grey"
         >GitHub</a>
+        <!-- audio tag - export以降にmp3ファイルのid(drive)を入れてやると再生できる -->
+        <audio preload="auto" controls>
+          <source src="http://drive.google.com/uc?export=view&id=1qpo6qpMScDKTNcKaekUoO4_WfirF_Jaa" type="audio/mp3">
+        </audio>
+        <!-- driveの埋め込みコード -->
+        <iframe src="https://drive.google.com/file/d/1qpo6qpMScDKTNcKaekUoO4_WfirF_Jaa/preview" width="350" height="70">
+        </iframe>
       </div>
     </div>
   </div>


### PR DESCRIPTION
mp3 ファイルをjsonで持ってくるのデータサイズ的に現実的でないらしいから、別の手段へ。

以下のコードで再生できたので、drive上のmp3ファイルのidさえあればいい模様。

``` 
       <audio preload="auto" controls>
          <source src="http://drive.google.com/uc?export=view&id=mp3ファイルのid" type="audio/mp3">
        </audio>
```

なので、今日はとりあえずdrive上のすべてのmp3ファイルidを配列で返すapi作っておきました。
nuxt内でapi叩いて、手に入れたidをhtmlの属性に入れてやってください。

多分前回のお二人の会議の感じだと、web audio api を使う予定だったと思うんですが
今日僕しかいなかったので独断の実装提案なので採用になったらpullしてください！
